### PR TITLE
Continuous Integration with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: 1.0.{build}
+configuration:
+- Debug
+- Release
+platform: x64
+before_build:
+- cmd: >-
+    set PATH=C:\Qt\5.6\msvc2015_64\bin;%PATH%
+
+    mkdir build
+
+    cd build
+
+    qmake -tp vc ../hdrv.pro "BOOST_ROOT=C:\Libraries\boost_1_60_0"
+
+    cd ..
+build:
+  project: build\hdrv.vcxproj
+  verbosity: minimal
+after_build:
+- cmd: 7z a hdrv_%CONFIGURATION%.zip %APPVEYOR_BUILD_FOLDER%\build\%CONFIGURATION%\hdrv.*
+artifacts:
+- path: hdrv_Debug.zip
+  name: HDRV Debug
+- path: hdrv_Release.zip
+  name: HDRV Release


### PR DESCRIPTION
This is a config for performing CI builds with [AppVeyor](http://www.appveyor.com/).

The packaging is currently incomplete, as it only zips up the exe but none of the dependency dlls that are present in the current release package. But it's already enough to verify that a commit doesn't accidentally break the build.

AppVeyor only does Windows builds, but I could also try to cook up a Travis config for Linux and OSX CI builds.
